### PR TITLE
Fix issue #21.

### DIFF
--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -521,7 +521,8 @@ class SymSpell(object):
         for si in suggestion_parts:
             joined_term += si.term + " "
             joined_count = min(joined_count, si.count)
-        suggestion = SuggestItem(joined_term.rstrip(),
+        joined_term = joined_term.rstrip()
+        suggestion = SuggestItem(joined_term,
                                  distance_comparer.compare(
                                      phrase, joined_term, 2 ** 31 - 1),
                                  joined_count)


### PR DESCRIPTION
This commit fixes incorrect distance computation of compound terms. Before this commit, there was additional whitespace at the end that caused the distance to be greater by 1.

Before commit: sym_spell.lookup_compound("whereis", 2) = where is, 360468349, 2
After commit:  sym_spell.lookup_compound("whereis", 2) = where is, 360468349, 1