### PR TITLE
Fix encoding to render Arabic text correctly.

### DIFF
--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -138,7 +138,7 @@ class SymSpell(object):
         return True
 
     def load_dictionary(self, corpus, term_index, count_index,
-                        encoding=None):
+                        encoding='utf-8'):
         """Load multiple dictionary entries from a file of
         word/frequency count pairs. Merges with any dictionary data
         already loaded.
@@ -164,7 +164,7 @@ class SymSpell(object):
                         self.create_dictionary_entry(key, count)
         return True
 
-    def create_dictionary(self, corpus, encoding=None):
+    def create_dictionary(self, corpus, encoding='utf-8'):
         """Load multiple dictionary words from a file containing plain
         text. Merges with any dictionary data already loaded.
 


### PR DESCRIPTION
Referencing this issue [https://github.com/mammothb/symspellpy/issues/28](url), the Arabic rendering issue was fixed by changing these 2 lines in symspellpy.py file.
I hope this helps.
