### PR TITLE
Update symspellpy.py

### DIFF
--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -497,16 +497,16 @@ class SymSpell(object):
                         # select best suggestion for split pair
                         suggestions_split.sort()
                         suggestion_parts.append(suggestions_split[0])
-                        self._replaced_words[term_list_1[i]] = suggestions_split[0]
+                        self._replaced_words[term_list_1[i]] = suggestions_split[0]._term
                     else:
                         si = SuggestItem(term_list_1[i],
                                          max_edit_distance + 1, 0)
                         suggestion_parts.append(si)
-                        self._replaced_words[term_list_1[i]] = si
+                        self._replaced_words[term_list_1[i]] = si._term
                 else:
                     si = SuggestItem(term_list_1[i], max_edit_distance + 1, 0)
                     suggestion_parts.append(si)
-                    self._replaced_words[term_list_1[i]] = si
+                    self._replaced_words[term_list_1[i]] = si._term
         joined_term = ""
         joined_count = sys.maxsize
         for si in suggestion_parts:


### PR DESCRIPTION
line # 500 , 505 & 509 

The attribute "_term " from the class "SuggesItem" has been removed in the updated version. This way calling the method "replaced_words" gives a dictionary which the values are SuggestItem class and form calling the user should manually retrieve the original word with "_.term" . 

Once my suggestion had been accepted but again in the updated version , the part "._term" has been removed for collection the replaced words and their origins. 

Hamed_ 