### PR TITLE
Adding casing transfer as post-processing to lookup() and lookup_comp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,27 @@ if __name__ == "__main__":
 ```
 ##### Expected output:
 `the quick brown fox jumps over the lazy dog 8 -34.491167981910635`
+
+
+### Transferring casing
+
+To transfer the casing (eg uppercase/lowercase) from the original phrase
+to the typo-corrected one, use the `transfer_casing` boolean flag of 
+the `lookup()` and the `lookup_compound()` methods:
+
+`lookup_compound()`:
+```
+suggestions = sym_spell.lookup_compound(input_term,
+                                        max_edit_distance_lookup,
+                                        transfer_casing=True)
+```
+
+`lookup()`:
+```
+suggestions = sym_spell.lookup(input_term,
+                               suggestion_verbosity,
+                               max_edit_distance_lookup,
+                               transfer_casing=True)
+```
+
+

--- a/symspellpy/helpers.py
+++ b/symspellpy/helpers.py
@@ -2,6 +2,8 @@
 .. module:: helpers
    :synopsis: Helper functions
 """
+from difflib import SequenceMatcher
+from itertools import zip_longest
 import re
 
 def null_distance_results(string1, string2, max_distance):
@@ -125,3 +127,116 @@ def is_acronym(word):
             abcde, ABCde, abcDE, abCDe, abc12, ab12c
     """
     return re.match(r"\b[A-Z0-9]{2,}\b", word) is not None
+
+def transfer_casing_for_matching_text(text_w_casing, text_wo_casing):
+    """ Transferring the casing from one text to another - assuming \
+    that they are 'matching' texts, alias they have the same length.
+    """
+    if len(text_w_casing) != len(text_wo_casing):
+        raise ValueError("The 'text_w_casing' and 'text_wo_casing' "
+                         "don't have the same length, "
+                         "so you can't use them with this method, "
+                         "you should be using the more general "
+                         "transfer_casing_similar_text() method.")
+
+    return ''.join([y.upper() if x.isupper() else y.lower()
+                    for x, y in zip(text_w_casing, text_wo_casing)])
+
+def transfer_casing_for_similar_text(text_w_casing, text_wo_casing):
+    """ Transferring the casing from one text to another - for similar \
+    (not matching) text
+
+    1. It will use difflib's SequenceMatcher
+       to identify the different type of changes needed to turn \
+       text1 into text2
+    2. For each type of change:
+       - for inserted sections:
+            - it will transfer the casing from the prior character
+            - if no character before or the character before is the \
+            space, then it will transfer the casing from the \
+            following character
+       - for deleted sections: no case transfer is required
+       - for equal sections: just swap out the text with the original, \
+       the one with the casings, as otherwise the two are the same
+       - replaced sections: transfer the casing using the \
+       transfer_casing_for_matching_text() method if the two has the same \
+       length, otherwise transfer character-by-character and carry the \
+       last casing over to any additional characters
+    """
+    if not text_wo_casing:
+        return text_wo_casing
+
+    if not text_w_casing:
+        raise ValueError("We need 'text_w_casing' to know what "
+                         "casing to transfer!")
+
+    _sm = SequenceMatcher(None, text_w_casing.lower(),
+                          text_wo_casing)
+
+    # we will collect the case_text:
+    c = ''
+
+    # get the operation codes describing the differences between the two
+    # strings and handle them based on the per operation code rules
+    for tag, i1, i2, j1, j2 in _sm.get_opcodes():
+        # Print the operation codes from the SequenceMatcher:
+        # print('{:7}   a[{}:{}] --> b[{}:{}] {!r:>8} --> {!r}'
+        #       .format(tag, i1, i2, j1, j2,
+        #               text_w_casing[i1:i2],
+        #               text_wo_casing[j1:j2]))
+
+        # inserted character(s)
+        if tag == 'insert':
+            # if this is the first character and so there is no character on
+            # the left of this or the left of it a space then take the casing
+            # from the following character
+            if i1 == 0 or text_w_casing[i1 - 1] == ' ':
+                if text_w_casing[i1] and text_w_casing[i1].isupper():
+                    c += text_wo_casing[j1:j2].upper()
+                else:
+                    c += text_wo_casing[j1:j2].lower()
+            else:
+                # otherwise just take the casing from the prior character
+                if text_w_casing[i1 - 1].isupper():
+                    c += text_wo_casing[j1:j2].upper()
+                else:
+                    c += text_wo_casing[j1:j2].lower()
+
+        elif tag == 'delete':
+            # for deleted characters we don't need to do anything
+            pass
+
+        elif tag == 'equal':
+            # for 'equal' we just transfer the text from the text_w_casing,
+            # as anyhow they are equal (without the casing)
+            c += text_w_casing[i1:i2]
+
+        elif tag == 'replace':
+            _w_casing = text_w_casing[i1:i2]
+            _wo_casing = text_wo_casing[j1:j2]
+
+            # if they are the same length, the transfer is easy
+            if len(_w_casing) == len(_wo_casing):
+                c += transfer_casing_for_matching_text(text_w_casing=
+                                                       _w_casing,
+                                                       text_wo_casing=
+                                                       _wo_casing)
+            else:
+                # if the replaced has a different length, then we transfer
+                # the casing character-by-character and using the last
+                # casing to continue if we run out of the sequence
+                _last = 'lower'
+                for w, wo in zip_longest(_w_casing, _wo_casing):
+                    if w and wo:
+                        if w.isupper():
+                            c += wo.upper()
+                            _last = 'upper'
+                        else:
+                            c += wo.lower()
+                            _last = 'lower'
+                    elif not w and wo:
+                        # once we ran out of 'w', we will carry over
+                        # the last casing to any additional 'wo' characters
+                        c += wo.upper() if _last == 'upper' else wo.lower()
+
+    return c

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,6 +1,7 @@
 import unittest
 
-from symspellpy.helpers import to_similarity
+from symspellpy.helpers import to_similarity,\
+    transfer_casing_for_matching_text, transfer_casing_for_similar_text
 
 class TestHelpers(unittest.TestCase):
     def test_to_similarity(self):
@@ -11,3 +12,29 @@ class TestHelpers(unittest.TestCase):
 
         distance_2 = -1.0
         self.assertEqual(-1, to_similarity(distance_2, length))
+
+    def test_transfer_casing_for_matching_text(self):
+        text_w_casing = "Haw is the eeather in New York?"
+        text_wo_casing = "how is the weather in new york?"
+        # the text_wo_casing text with the casing transferred from
+        # the text_w_casing text
+        text_wo_casing_transferred = "How is the weather in New York?"
+
+        self.assertEqual(text_wo_casing_transferred,
+                         transfer_casing_for_matching_text(text_w_casing=
+                                                           text_w_casing,
+                                                           text_wo_casing=
+                                                           text_wo_casing))
+
+    def test_transfer_casing_for_similar_text(self):
+        text_w_casing = "Haaw is the weeather in New York?"
+        text_wo_casing = "how is the weather in new york?"
+        # the text_wo_casing text with the casing transferred from
+        # the text_w_casing text
+        text_wo_casing_transferred = "How is the weather in New York?"
+
+        self.assertEqual(text_wo_casing_transferred,
+                         transfer_casing_for_similar_text(text_w_casing=
+                                                          text_w_casing,
+                                                          text_wo_casing=
+                                                          text_wo_casing))

--- a/test/test_symspellpy.py
+++ b/test/test_symspellpy.py
@@ -658,3 +658,54 @@ class TestSymSpellPy(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual("steama", result[0].term)
         self.assertEqual(len("steama"), sym_spell._max_length)
+
+    def test_lookup_transfer_casing(self):
+        sym_spell = SymSpell()
+        sym_spell.create_dictionary_entry("steam", 4)
+        result = sym_spell.lookup("Stream", Verbosity.TOP, 2,
+                                  transfer_casing=True)
+        self.assertEqual("Steam", result[0].term)
+
+        sym_spell = SymSpell()
+        sym_spell.create_dictionary_entry("steam", 4)
+        result = sym_spell.lookup("StreaM", Verbosity.TOP, 2,
+                                  transfer_casing=True)
+        self.assertEqual("SteaM", result[0].term)
+
+        sym_spell = SymSpell()
+        sym_spell.create_dictionary_entry("steam", 4)
+        result = sym_spell.lookup("STREAM", Verbosity.TOP, 2,
+                                  transfer_casing=True)
+        self.assertEqual("STEAM", result[0].term)
+
+    def test_lookup_compound_transfer_casing(self):
+        edit_distance_max = 2
+        prefix_length = 7
+        sym_spell = SymSpell(edit_distance_max, prefix_length)
+        sym_spell.load_dictionary(self.dictionary_path, 0, 1)
+
+        typo = ("Whereis th elove hehaD Dated forImuch of thepast who "
+                "couqdn'tread in sixthgrade AND ins pired him")
+        correction = ("Where is the love he haD Dated for much of the past "
+                      "who couldn't read in sixth grade AND inspired him")
+
+        results = sym_spell.lookup_compound(typo, edit_distance_max,
+                                            transfer_casing=True)
+        self.assertEqual(correction, results[0].term)
+
+    def test_lookup_compound_transfer_casing_ignore_nonwords(self):
+        edit_distance_max = 2
+        prefix_length = 7
+        sym_spell = SymSpell(edit_distance_max, prefix_length)
+        sym_spell.load_dictionary(self.dictionary_path, 0, 1)
+
+        typo = ("Whereis th elove hehaD Dated FOREEVER forImuch of thepast who"
+                " couqdn'tread in sixthgrade AND ins pired him")
+        correction = ("Where is the love he haD Dated FOREEVER for much of the"
+                      " past who couldn't read in sixth grade AND inspired "
+                      "him")
+
+        results = sym_spell.lookup_compound(typo, edit_distance_max,
+                                            ignore_non_words=True,
+                                            transfer_casing=True)
+        self.assertEqual(correction, results[0].term)


### PR DESCRIPTION
…ound()

I have added a post-processing step allowing us to transfer the casing (eg lowercase / uppercase) to the typo-fixed text.
It uses the difflib module's SequenceMatcher to identify the differences between the original phrase and the typo-fixed one and then we carry over the casing based on the type of operation required to transform text1 to text2.