### PR TITLE
2x to 4x improved symspell performance 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 codecov
 coverage
 pytest-cov
+editdistance

--- a/symspellpy/editdistance.py
+++ b/symspellpy/editdistance.py
@@ -4,12 +4,14 @@
 """
 from enum import Enum
 
+import editdistance
 import symspellpy.helpers as helpers
 
 class DistanceAlgorithm(Enum):
     """Supported edit distance algorithms"""
     LEVENSHTEIN = 0  #: Levenshtein algorithm.
     DAMERUAUOSA = 1  #: Damerau optimal string alignment algorithm
+    LAVENSHTEIN_FAST = 2  #: faster implementation of the alg
 
 class EditDistance(object):
     """Edit distance algorithms.
@@ -39,6 +41,8 @@ class EditDistance(object):
             self._distance_comparer = Levenshtein()
         elif algorithm == DistanceAlgorithm.DAMERUAUOSA:
             self._distance_comparer = DamerauOsa()
+        elif algorithm == DistanceAlgorithm.LAVENSHTEIN_FAST:
+            self._distance_comparer = LavenshteinFast()
         else:
             raise ValueError("Unknown distance algorithm")
 
@@ -91,6 +95,13 @@ class AbstractDistanceComparer(object):
             If called from abstract class instead of concrete class
         """
         raise NotImplementedError("Should have implemented this")
+
+
+class LavenshteinFast(AbstractDistanceComparer):
+    def distance(self, string_1, string_2, max_distance):
+        dist = editdistance.eval(string_1, string_2)
+        return dist if dist <= max_distance else -1
+
 
 class Levenshtein(AbstractDistanceComparer):
     """Class providing Levenshtein algorithm for computing edit

--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -107,7 +107,7 @@ class SymSpell(object):
         self._max_dictionary_edit_distance = max_dictionary_edit_distance
         self._prefix_length = prefix_length
         self._count_threshold = count_threshold
-        self._distance_algorithm = DistanceAlgorithm.DAMERUAUOSA
+        self._distance_algorithm = DistanceAlgorithm.LAVENSHTEIN_FAST
         self._max_length = 0
         self._replaced_words = dict()
 


### PR DESCRIPTION
Hi
I run a benchmark over the code and saw that the most expensive calculation was the distance between strings. I propose to use the fastest (to my knowledge) implementation of Levenshtein distance, which results in a great performance boost.