### PR TITLE
Include bigram dictionary in save and load pickle methods

### DIFF
--- a/docs/api/symspellpy.rst
+++ b/docs/api/symspellpy.rst
@@ -5,19 +5,26 @@ symspellpy
 Enum class
 ==========
 
-.. autoclass:: symspellpy.symspellpy.Verbosity
+.. autoclass:: symspellpy.verbosity.Verbosity
    :members:
 
-Data classes
-============
+Data class
+==========
 
-.. autoclass:: symspellpy.symspellpy.SuggestItem
+.. autoclass:: symspellpy.suggest_item.SuggestItem
    :members:
    :special-members: __eq__, __lt__, __str__
 
-.. autoclass:: symspellpy.symspellpy.Composition
+.. autoclass:: symspellpy.composition.Composition
    :members:
    :exclude-members: corrected_string, distance_sum, log_prob_sum, segmented_string
+
+Utility class
+=============
+
+.. autoclass:: symspellpy.pickle_mixin.PickleMixin
+   :members:
+   :private-members:
 
 SymSpell
 ========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ profile = "black"
 [tool.pylint]
     [tool.pylint.'MESSAGES CONTROL']
         disable = [
+            "logging-fstring-interpolation",
             "too-many-arguments",
             "too-many-branches",
             "too-many-instance-attributes",

--- a/symspellpy/__init__.py
+++ b/symspellpy/__init__.py
@@ -21,6 +21,14 @@
 
 __version__ = "6.7.0.dev1"
 
+import logging
+import os
+
 from . import editdistance, helpers
 from .symspellpy import SymSpell
 from .verbosity import Verbosity
+
+logging.basicConfig(
+    level=os.environ.get("LOGLEVEL", "WARNING"),
+    format="%(asctime)s %(levelname)s:%(message)s",
+)

--- a/symspellpy/pickle_mixin.py
+++ b/symspellpy/pickle_mixin.py
@@ -43,12 +43,15 @@ class PickleMixin:
     """Implements saving and loading pickle functionality for SymSpell."""
 
     data_version: int
-    _count_threshold: int
+    _below_threshold_words: Dict[str, int]
+    _bigrams: Dict[str, int]
     _deletes: Dict[str, List[str]]
+    _words: Dict[str, int]
+
+    _count_threshold: int
     _max_dictionary_edit_distance: int
     _max_length: int
     _prefix_length: int
-    _words: Dict[str, int]
 
     def load_pickle(
         self,
@@ -62,7 +65,7 @@ class PickleMixin:
         Args:
             data: Either bytes string to be used with ``from_bytes=True`` or the
                 path+filename of the pickle file to be used with
-                `from_bytes=False``.
+                ``from_bytes=False``.
             compressed: A flag to determine whether to read the pickled data as
                 compressed data.
             from_bytes: Flag to determine if we are loading from bytes or file.
@@ -96,7 +99,7 @@ class PickleMixin:
                 instead of wrting to file.
 
         Returns:
-            A byte string of the pickled data if ``to_bytes`` is ``True``.
+            A byte string of the pickled data if ``to_bytes=True``.
         """
         if to_bytes:
             return self._save_pickle_stream(to_bytes=to_bytes)
@@ -175,7 +178,7 @@ class PickleMixin:
                 instead of wrting to file.
 
         Returns:
-            A byte string of the pickled data if ``to_bytes`` is ``True``.
+            A byte string of the pickled data if ``to_bytes=True``.
         """
         pickle_data = {
             # Dictionary entries related variables

--- a/symspellpy/pickle_mixin.py
+++ b/symspellpy/pickle_mixin.py
@@ -1,0 +1,198 @@
+# MIT License
+#
+# Copyright (c) 2021 mmb L (Python port)
+# Copyright (c) 2021 Wolf Garbe (Original C# implementation)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+"""
+.. module:: pickle_mixing
+   :synopsis: Mixin to provide pickle loading and saving functionalities.
+"""
+
+import gzip
+import logging
+import pickle
+from operator import itemgetter
+from pathlib import Path
+from typing import IO, Dict, List, Optional, Union, cast
+
+logger = logging.getLogger(__name__)
+
+
+# Protocol only available in py38
+# class SymSpellProtocol(Protocol):
+#     data_version: int
+#     _count_threshold: int
+#     _max_dictionary_edit_distance: int
+#     _prefix_length: int
+#     _deletes: Dict[str, List[str]]
+#     _words: Dict[str, int]
+#     _max_length: int
+
+
+class PickleMixin:
+    """Implements saving and loading pickle functionality for SymSpell."""
+
+    data_version: int
+    _count_threshold: int
+    _deletes: Dict[str, List[str]]
+    _max_dictionary_edit_distance: int
+    _max_length: int
+    _prefix_length: int
+    _words: Dict[str, int]
+
+    def load_pickle(
+        self,
+        data: Union[bytes, Path],
+        compressed: bool = True,
+        from_bytes: bool = False,
+    ) -> bool:
+        """Loads delete combination from file as pickle. This will reduce the
+        loading time compared to running :meth:`load_dictionary` again.
+
+        Args:
+            data: Either bytes string to be used with ``from_bytes=True`` or the
+                path+filename of the pickle file to be used with
+                `from_bytes=False``.
+            compressed: A flag to determine whether to read the pickled data as
+                compressed data.
+            from_bytes: Flag to determine if we are loading from bytes or file.
+
+        Returns:
+            ``True`` if delete combinations are successfully loaded.
+        """
+        if from_bytes:
+            assert isinstance(data, bytes)
+            return self._load_pickle_stream(data, from_bytes)
+        if compressed:
+            with gzip.open(data, "rb") as gzip_infile:
+                return self._load_pickle_stream(cast(IO[bytes], gzip_infile))
+        else:
+            with open(data, "rb") as infile:
+                return self._load_pickle_stream(infile)
+
+    def save_pickle(
+        self,
+        filename: Optional[Path] = None,
+        compressed: bool = True,
+        to_bytes: bool = False,
+    ) -> Optional[bytes]:
+        """Pickles :attr:`_deletes`, :attr:`_words`, and :attr:`_max_length` into
+        a stream for quicker loading later.
+
+        Args:
+            filename: The path+filename of the pickle file.
+            compressed: A flag to determine whether to compress the pickled data.
+            to_bytes: Flag to determine by bytes string should be returned
+                instead of wrting to file.
+
+        Returns:
+            A byte string of the pickled data if ``to_bytes`` is ``True``.
+        """
+        if to_bytes:
+            return self._save_pickle_stream(to_bytes=to_bytes)
+        assert filename is not None
+        if compressed:
+            with gzip.open(filename, "wb") as gzip_outfile:
+                self._save_pickle_stream(cast(IO[bytes], gzip_outfile))
+        else:
+            with open(filename, "wb") as outfile:
+                self._save_pickle_stream(outfile)
+        return None
+
+    def _load_pickle_stream(
+        self, stream: Union[bytes, IO[bytes]], from_bytes: bool = False
+    ) -> bool:
+        """Loads delete combination from stream as pickle. This will reduce the
+        loading time compared to running :meth:`load_dictionary` again.
+
+        **NOTE**: Prints warning if the current settings `count_threshold`,
+        `max_dictionary_edit_distance`, and `prefix_length` are different from
+        the loaded settings. Overwrite current settings with loaded settings.
+
+        Args:
+            stream: The stream from which the pickle data is loaded.
+            from_bytes: Flag to determine if we are loading from bytes or file.
+
+        Returns:
+            ``True`` if delete combinations are successfully loaded.
+        """
+        if from_bytes:
+            assert isinstance(stream, bytes)
+            pickle_data = pickle.loads(stream)  # nosec
+        else:
+            assert not isinstance(stream, bytes)
+            pickle_data = pickle.load(stream)  # nosec
+        if pickle_data.get("data_version", None) != self.data_version:
+            return False
+        settings = ("count_threshold", "max_dictionary_edit_distance", "prefix_length")
+        if itemgetter(*settings)(pickle_data) != (
+            self._count_threshold,
+            self._max_dictionary_edit_distance,
+            self._prefix_length,
+        ):
+            logger.warning(
+                f"Loading data which was created using different {settings} settings. "
+                "Overwriting current SymSpell instance with loaded settings ..."
+            )
+        self._deletes = pickle_data["deletes"]
+        self._words = pickle_data["words"]
+        self._max_length = pickle_data["max_length"]
+        # Dictionary entries related variables
+        self._below_threshold_words = pickle_data["below_threshold_words"]
+        self._bigrams = pickle_data["bigrams"]
+        self._deletes = pickle_data["deletes"]
+        self._words = pickle_data["words"]
+        self._max_length = pickle_data["max_length"]
+        # SymSpell settings used to generate the above
+        self._count_threshold = pickle_data["count_threshold"]
+        self._max_dictionary_edit_distance = pickle_data["max_dictionary_edit_distance"]
+        self._prefix_length = pickle_data["prefix_length"]
+        return True
+
+    def _save_pickle_stream(
+        self, stream: Optional[IO[bytes]] = None, to_bytes=False
+    ) -> Optional[bytes]:
+        """Pickles :attr:`_below_threshold_words`, :attr:`_bigrams`,
+        :attr:`_deletes`, :attr:`_words`, and :attr:`_max_length` into
+        a stream for quicker loading later.
+
+        Pickles :attr:`_count_threshold`, :attr:`_max_dictionary_edit_distance`,
+        and :attr:`_prefix_length` to ensure consistent behavior.
+
+        Args:
+            stream: The stream to store the pickle data.
+            to_bytes: Flag to determine by bytes string should be returned
+                instead of wrting to file.
+
+        Returns:
+            A byte string of the pickled data if ``to_bytes`` is ``True``.
+        """
+        pickle_data = {
+            # Dictionary entries related variables
+            "below_threshold_words": self._below_threshold_words,
+            "bigrams": self._bigrams,
+            "deletes": self._deletes,
+            "words": self._words,
+            "max_length": self._max_length,
+            # SymSpell settings used to generate the above
+            "count_threshold": self._count_threshold,
+            "max_dictionary_edit_distance": self._max_dictionary_edit_distance,
+            "prefix_length": self._prefix_length,
+            # Version to ensure compatibility
+            "data_version": self.data_version,
+        }
+        if to_bytes:
+            return pickle.dumps(pickle_data)
+        assert stream is not None
+        pickle.dump(pickle_data, stream)
+        return None

--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -67,7 +67,7 @@ class SymSpell:
         ValueError: If `count_threshold` is negative.
     """
 
-    data_version = 2
+    data_version = 3
     # Number of all words in the corpus used to generate the frequency
     # dictionary. This is used to calculate the word occurrence probability p
     # from word counts c : p=c/N. N equals the sum of all counts c in the
@@ -1148,19 +1148,41 @@ class SymSpell:
         self._deletes = pickle_data["deletes"]
         self._words = pickle_data["words"]
         self._max_length = pickle_data["max_length"]
+        # Dictionary entries related variables
+        self._below_threshold_words = pickle_data["below_threshold_words"]
+        self._bigrams = pickle_data["bigrams"]
+        self._deletes = pickle_data["deletes"]
+        self._words = pickle_data["words"]
+        self._max_length = pickle_data["max_length"]
+        # SymSpell settings used to generate the above
+        self._count_threshold = pickle_data["count_threshold"]
+        self._max_dictionary_edit_distance = pickle_data["max_dictionary_edit_distance"]
+        self._prefix_length = pickle_data["prefix_length"]
         return True
 
     def _save_pickle_stream(self, stream: IO[bytes]) -> None:
-        """Pickle :attr:`_deletes`, :attr:`_words`, and :attr:`_max_length` into
+        """Pickles :attr:`_below_threshold_words`, :attr:`_bigrams`,
+        :attr:`_deletes`, :attr:`_words`, and :attr:`_max_length` into
         a stream for quicker loading later.
+
+        Pickles :attr:`_count_threshold`, :attr:`_max_dictionary_edit_distance`,
+        and :attr:`_prefix_length` to ensure consistent behavior.
 
         Args:
             stream: The stream to store the pickle data.
         """
         pickle_data = {
+            # Dictionary entries related variables
+            "below_threshold_words": self._below_threshold_words,
+            "bigrams": self._bigrams,
             "deletes": self._deletes,
             "words": self._words,
             "max_length": self._max_length,
+            # SymSpell settings used to generate the above
+            "count_threshold": self._count_threshold,
+            "max_dictionary_edit_distance": self._max_dictionary_edit_distance,
+            "prefix_length": self._prefix_length,
+            # Version to ensure compatibility
             "data_version": self.data_version,
         }
         pickle.dump(pickle_data, stream)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,11 @@ def dictionary_path():
 
 
 @pytest.fixture
+def pickle_path():
+    return FORTESTS_DIR / "dictionary.pickle"
+
+
+@pytest.fixture
 def query_path():
     return FORTESTS_DIR / "noisy_query_en_1000.txt"
 

--- a/tests/test_symspellpy_pickle.py
+++ b/tests/test_symspellpy_pickle.py
@@ -1,0 +1,122 @@
+import os
+import pickle
+from unittest import TestCase
+
+import pytest
+
+from symspellpy import SymSpell
+
+
+class TestSymSpellPyPickle:
+    @pytest.mark.parametrize(
+        "symspell_default_load, is_compressed",
+        [("unigram", True), ("bigram", True), ("unigram", False), ("bigram", False)],
+        indirect=["symspell_default_load"],
+    )
+    def test_pickle(self, pickle_path, symspell_default_load, is_compressed):
+        sym_spell, _ = symspell_default_load
+        sym_spell.save_pickle(pickle_path, is_compressed)
+
+        sym_spell_2 = SymSpell(123, 456, 789)
+
+        assert sym_spell._count_threshold != sym_spell_2._count_threshold
+        assert (
+            sym_spell._max_dictionary_edit_distance
+            != sym_spell_2._max_dictionary_edit_distance
+        )
+        assert sym_spell._prefix_length != sym_spell_2._prefix_length
+
+        with TestCase.assertLogs("symspellpy.symspellpy.logger", level="WARNING") as cm:
+            sym_spell_2.load_pickle(pickle_path, is_compressed)
+        assert (
+            "Loading data which was created using different ('count_threshold', "
+            "'max_dictionary_edit_distance', 'prefix_length') settings. Overwriting "
+            "current SymSpell instance with loaded settings ..."
+        ) == cm.records[0].getMessage()
+        assert sym_spell.below_threshold_words == sym_spell_2.below_threshold_words
+        assert sym_spell.bigrams == sym_spell_2.bigrams
+        assert sym_spell.deletes == sym_spell_2.deletes
+        assert sym_spell.words == sym_spell_2.words
+        assert sym_spell._max_length == sym_spell_2._max_length
+        assert sym_spell._count_threshold == sym_spell_2._count_threshold
+        assert (
+            sym_spell._max_dictionary_edit_distance
+            == sym_spell_2._max_dictionary_edit_distance
+        )
+        assert sym_spell._prefix_length == sym_spell_2._prefix_length
+        os.remove(pickle_path)
+
+    @pytest.mark.parametrize(
+        "symspell_default_load, is_compressed",
+        [("unigram", True), ("bigram", True), ("unigram", False), ("bigram", False)],
+        indirect=["symspell_default_load"],
+    )
+    def test_pickle_same_settings(
+        self, pickle_path, symspell_default_load, is_compressed
+    ):
+        sym_spell, _ = symspell_default_load
+        sym_spell.save_pickle(pickle_path, is_compressed)
+
+        sym_spell_2 = SymSpell()
+        sym_spell_2.load_pickle(pickle_path, is_compressed)
+
+        assert sym_spell.below_threshold_words == sym_spell_2.below_threshold_words
+        assert sym_spell.bigrams == sym_spell_2.bigrams
+        assert sym_spell.deletes == sym_spell_2.deletes
+        assert sym_spell.words == sym_spell_2.words
+        assert sym_spell._max_length == sym_spell_2._max_length
+        assert sym_spell._count_threshold == sym_spell_2._count_threshold
+        assert (
+            sym_spell._max_dictionary_edit_distance
+            == sym_spell_2._max_dictionary_edit_distance
+        )
+        assert sym_spell._prefix_length == sym_spell_2._prefix_length
+        os.remove(pickle_path)
+
+    @pytest.mark.parametrize(
+        "symspell_default_load", ["unigram", "bigram"], indirect=True
+    )
+    def test_pickle_bytes(self, symspell_default_load):
+        sym_spell, _ = symspell_default_load
+        sym_spell_2 = SymSpell(123, 456, 789)
+
+        assert sym_spell._count_threshold != sym_spell_2._count_threshold
+        assert (
+            sym_spell._max_dictionary_edit_distance
+            != sym_spell_2._max_dictionary_edit_distance
+        )
+        assert sym_spell._prefix_length != sym_spell_2._prefix_length
+
+        with TestCase.assertLogs("symspellpy.symspellpy.logger", level="WARNING") as cm:
+            sym_spell_2.load_pickle(
+                sym_spell.save_pickle(to_bytes=True), from_bytes=True
+            )
+        assert (
+            "Loading data which was created using different ('count_threshold', "
+            "'max_dictionary_edit_distance', 'prefix_length') settings. Overwriting "
+            "current SymSpell instance with loaded settings ..."
+        ) == cm.records[0].getMessage()
+        assert sym_spell.below_threshold_words == sym_spell_2.below_threshold_words
+        assert sym_spell.bigrams == sym_spell_2.bigrams
+        assert sym_spell.deletes == sym_spell_2.deletes
+        assert sym_spell.words == sym_spell_2.words
+        assert sym_spell._max_length == sym_spell_2._max_length
+        assert sym_spell._count_threshold == sym_spell_2._count_threshold
+        assert (
+            sym_spell._max_dictionary_edit_distance
+            == sym_spell_2._max_dictionary_edit_distance
+        )
+        assert sym_spell._prefix_length == sym_spell_2._prefix_length
+
+    def test_pickle_invalid(self, pickle_path, symspell_default):
+        pickle_data = {"deletes": {}, "words": {}, "max_length": 0, "data_version": -1}
+        with open(pickle_path, "wb") as f:
+            pickle.dump(pickle_data, f)
+        assert not symspell_default.load_pickle(pickle_path, False)
+        os.remove(pickle_path)
+
+        pickle_data = {"deletes": {}, "words": {}, "max_length": 0}
+        with open(pickle_path, "wb") as f:
+            pickle.dump(pickle_data, f)
+        assert not symspell_default.load_pickle(pickle_path, False)
+        os.remove(pickle_path)


### PR DESCRIPTION
Closes https://github.com/mammothb/symspellpy/issues/93

**Changes**:
- Shifted pickle related methods to `PickleMixin`
- Added `_below_threshold_words`, `_bigrams`, `_count_threshold`, `_max_dictionary_edit_distance`, and `_prefix_length` to pickle. Updated `data_version` to 3.
- Implemented `to_bytes` and `from_bytes` option to use `pickle.dumps()` and `pickle.loads()` instead.
- Prints warning if the `_count_threshold`, `_max_dictionary_edit_distance`, and `_prefix_length` settings from the loaded pickle do not match the settings of the current `SymSpell` instance.
  - Overwrites the current settings with the loaded settings.