### PR TITLE
fix: update _replaced_words when combi is best match

### DIFF
--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -690,6 +690,7 @@ class SymSpell(PickleMixin):
                     ):
                         suggestions_combi[0].distance += 1
                         suggestion_parts[-1] = suggestions_combi[0]
+                        self._replaced_words[terms_1[i - 1]] = suggestions_combi[0]
                         is_last_combi = True
                         continue
             is_last_combi = False

--- a/tests/fortests/lookup_compound_replaced_words_data.json
+++ b/tests/fortests/lookup_compound_replaced_words_data.json
@@ -13,7 +13,7 @@
           "thepast": "the past",
           "couqdn'tread": "couldn't read",
           "sixthgrade": "sixth grade",
-          "ins": "in"
+          "ins": "inspired"
         }
       },
       "unigram": {
@@ -27,7 +27,7 @@
           "thepast": "the past",
           "couqdn'tread": "couldn't read",
           "sixthgrade": "sixth grade",
-          "ins": "in"
+          "ins": "inspired"
         }
       }
     },


### PR DESCRIPTION
In lookup_compound, update `_replaced_words` when a combi (`term[i - 1] + term[i]`) is the best suggestion.