### PR TITLE
Feat: change distance comparer

### DIFF
--- a/symspellpy/editdistance.py
+++ b/symspellpy/editdistance.py
@@ -65,7 +65,7 @@ class EditDistance:
         elif algorithm == DistanceAlgorithm.DAMERAU_OSA_FAST:
             self._distance_comparer = DamerauOsaFast()
         else:
-            raise ValueError("Unknown distance algorithm")
+            raise ValueError("unknown distance algorithm")
 
     def compare(self, string_1: str, string_2: str, max_distance: int) -> int:
         """Compares a string to the base string to determine the edit distance,

--- a/symspellpy/helpers.py
+++ b/symspellpy/helpers.py
@@ -40,8 +40,8 @@ def case_transfer_matching(cased_text: str, uncased_text: str) -> str:
     """
     if len(cased_text) != len(uncased_text):
         raise ValueError(
-            "'cased_text' and 'uncased_text' don't have the same length. Use "
-            "case_transfer_similar() instead."
+            "'cased_text' and 'uncased_text' don't have the same length, use "
+            "case_transfer_similar() instead"
         )
 
     return "".join(
@@ -84,7 +84,7 @@ def case_transfer_similar(cased_text: str, uncased_text: str) -> str:
         return uncased_text
 
     if not cased_text:
-        raise ValueError("'cased_text' cannot be empty!")
+        raise ValueError("'cased_text' cannot be empty")
 
     matcher = SequenceMatcher(a=cased_text.lower(), b=uncased_text)
     result = ""

--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -365,7 +365,7 @@ class SymSpell(PickleMixin):
         if max_edit_distance is None:
             max_edit_distance = self._max_dictionary_edit_distance
         if max_edit_distance > self._max_dictionary_edit_distance:
-            raise ValueError("Distance too large")
+            raise ValueError("distance too large")
         suggestions: List[SuggestItem] = []
         phrase_len = len(phrase)
 

--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -126,6 +126,19 @@ class SymSpell(PickleMixin):
         return self._deletes
 
     @property
+    def distance_algorithm(self) -> DistanceAlgorithm:
+        """The current distance algorithm."""
+        return self._distance_algorithm
+
+    @distance_algorithm.setter
+    def distance_algorithm(self, value: DistanceAlgorithm) -> None:
+        if not isinstance(value, DistanceAlgorithm):
+            raise TypeError(
+                "can only assign DistanceAlgorithm type values to distance_algorithm"
+            )
+        self._distance_algorithm = value
+
+    @property
     def entry_count(self) -> int:
         """Number of unique correct spelling words."""
         return len(self._deletes)

--- a/tests/test_editdistance.py
+++ b/tests/test_editdistance.py
@@ -139,7 +139,7 @@ class TestEditDistance:
     def test_unknown_distance_algorithm(self):
         with pytest.raises(ValueError) as excinfo:
             _ = EditDistance(2)
-        assert "Unknown distance algorithm" == str(excinfo.value)
+        assert "unknown distance algorithm" == str(excinfo.value)
 
     def test_abstract_distance_comparer(self):
         with pytest.raises(TypeError) as excinfo:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -55,8 +55,8 @@ class TestHelpers:
         with pytest.raises(ValueError) as excinfo:
             case_transfer_matching("abc", "abcd")
         assert (
-            "'cased_text' and 'uncased_text' don't have the same length. Use "
-            "case_transfer_similar() instead."
+            "'cased_text' and 'uncased_text' don't have the same length, use "
+            "case_transfer_similar() instead"
         ) == str(excinfo.value)
 
     def test_case_transfer_matching(self):
@@ -78,7 +78,7 @@ class TestHelpers:
     def test_case_transfer_similar_empty_w_casing(self):
         with pytest.raises(ValueError) as excinfo:
             case_transfer_similar("", "abcd")
-        assert "'cased_text' cannot be empty!" == str(excinfo.value)
+        assert "'cased_text' cannot be empty" == str(excinfo.value)
 
     def test_case_transfer_similar(self, get_similar_texts):
         for cased_text, uncased_text, expected in get_similar_texts:

--- a/tests/test_symspellpy.py
+++ b/tests/test_symspellpy.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from symspellpy import SymSpell, Verbosity
+from symspellpy.editdistance import DistanceAlgorithm
 from symspellpy.helpers import DictIO
 
 FORTESTS_DIR = Path(__file__).resolve().parent / "fortests"
@@ -60,6 +61,27 @@ class TestSymSpellPy:
         with pytest.raises(ValueError) as excinfo:
             _ = SymSpell(1, 3, -1)
         assert "count_threshold cannot be negative" == str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "algorithm",
+        [
+            DistanceAlgorithm.LEVENSHTEIN,
+            DistanceAlgorithm.DAMERAU_OSA,
+            DistanceAlgorithm.LEVENSHTEIN_FAST,
+            DistanceAlgorithm.DAMERAU_OSA_FAST,
+        ],
+    )
+    def test_set_distance_algorithm(self, symspell_default, algorithm):
+        symspell_default.distance_algorithm = algorithm
+        assert algorithm == symspell_default.distance_algorithm
+
+    def test_set_invalid_distance_algorithm(self, symspell_default):
+        with pytest.raises(TypeError) as excinfo:
+            symspell_default.distance_algorithm = 1
+        assert (
+            "can only assign DistanceAlgorithm type values to distance_algorithm"
+            == str(excinfo.value)
+        )
 
     @pytest.mark.parametrize("symspell_short", [None, 0], indirect=True)
     def test_create_dictionary_entry_negative_count(self, symspell_short):

--- a/tests/test_symspellpy_lookup.py
+++ b/tests/test_symspellpy_lookup.py
@@ -121,7 +121,7 @@ class TestSymSpellPyLookup:
     def test_max_edit_distance_too_large(self, symspell_high_thres_flame):
         with pytest.raises(ValueError) as excinfo:
             _ = symspell_high_thres_flame.lookup("flam", Verbosity.TOP, 3)
-        assert "Distance too large" == str(excinfo.value)
+        assert "distance too large" == str(excinfo.value)
 
     def test_include_unknown(self, symspell_high_thres_flame):
         result = symspell_high_thres_flame.lookup("flam", Verbosity.TOP, 0, True)


### PR DESCRIPTION
- Mentioned as missing feature in https://github.com/mammothb/symspellpy/issues/70#issuecomment-583693954
- Raises `TypeError` if not assigning to a `DistanceAlgorithm` type variable