### PR TITLE
fix: set count of ignored word to N

### DIFF
--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -677,10 +677,10 @@ class SymSpell(PickleMixin):
         for i, _ in enumerate(terms_1):
             if ignore_non_words:
                 if helpers.try_parse_int64(terms_1[i]) is not None:
-                    suggestion_parts.append(SuggestItem(terms_1[i], 0, 0))
+                    suggestion_parts.append(SuggestItem(terms_1[i], 0, self.N))
                     continue
                 if helpers.is_acronym(terms_2[i], ignore_term_with_digits):
-                    suggestion_parts.append(SuggestItem(terms_2[i], 0, 0))
+                    suggestion_parts.append(SuggestItem(terms_2[i], 0, self.N))
                     continue
             suggestions = self.lookup(terms_1[i], Verbosity.TOP, max_edit_distance)
             # combi check, always before split


### PR DESCRIPTION
Previously the count of these ignored words were set to 0, causing `lookup_compound` to always return suggestion count as 0 after it was changed to use Naive Bayes probability.

This sets the count of ignored words to N so they will not affect the final suggestion count/probability.