### PR TITLE
feat: log error message when dictionary file does not exist

### DIFF
--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -18,6 +18,7 @@
    :synopsis: Module for Symmetric Delete spelling correction algorithm.
 """
 
+import logging
 import math
 import re
 import string
@@ -34,6 +35,8 @@ from symspellpy.editdistance import DistanceAlgorithm, EditDistance
 from symspellpy.pickle_mixin import PickleMixin
 from symspellpy.suggest_item import SuggestItem
 from symspellpy.verbosity import Verbosity
+
+logger = logging.getLogger(__name__)
 
 
 class SymSpell(PickleMixin):
@@ -178,6 +181,7 @@ class SymSpell(PickleMixin):
         if isinstance(corpus, (Path, str)):
             corpus = Path(corpus)
             if not corpus.exists():
+                logger.error(f"Corpus not found at {corpus}.")
                 return False
             with open(corpus, "r", encoding=encoding) as infile:
                 for line in infile:
@@ -304,6 +308,7 @@ class SymSpell(PickleMixin):
         """
         corpus = Path(corpus)
         if not corpus.exists():
+            logger.error(f"Bigram dictionary file not found at {corpus}.")
             return False
         with open(corpus, "r", encoding=encoding) as infile:
             return self._load_bigram_dictionary_stream(
@@ -335,6 +340,7 @@ class SymSpell(PickleMixin):
         """
         corpus = Path(corpus)
         if not corpus.exists():
+            logger.error(f"Dictionary file not found at {corpus}.")
             return False
         with open(corpus, "r", encoding=encoding) as infile:
             return self._load_dictionary_stream(

--- a/tests/test_symspellpy.py
+++ b/tests/test_symspellpy.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import TestCase
 
 import pytest
 
@@ -121,7 +122,12 @@ class TestSymSpellPy:
             assert expected_count == result[0].count
 
     def test_load_bigram_dictionary_invalid_path(self, symspell_default):
-        assert not symspell_default.load_bigram_dictionary(INVALID_PATH, 0, 2)
+        with TestCase.assertLogs("symspellpy.symspellpy.logger", level="ERROR") as cm:
+            assert not symspell_default.load_bigram_dictionary(INVALID_PATH, 0, 2)
+        assert (
+            f"Bigram dictionary file not found at {Path(INVALID_PATH)}."
+            == cm.records[0].getMessage()
+        )
 
     def test_loading_dictionary_from_fileobject(self, symspell_default):
         with open(BIG_WORDS_PATH, "r", encoding="utf8") as infile:
@@ -171,7 +177,12 @@ class TestSymSpellPy:
         assert 12997637966 == symspell_default.bigrams["and"]
 
     def test_load_dictionary_invalid_path(self, symspell_default):
-        assert not symspell_default.load_dictionary(INVALID_PATH, 0, 1)
+        with TestCase.assertLogs("symspellpy.symspellpy.logger", level="ERROR") as cm:
+            assert not symspell_default.load_dictionary(INVALID_PATH, 0, 1)
+        assert (
+            f"Dictionary file not found at {Path(INVALID_PATH)}."
+            == cm.records[0].getMessage()
+        )
 
     def test_load_dictionary_bad_dictionary(self, symspell_default):
         assert symspell_default.load_dictionary(BAD_DICT_PATH, 0, 1)
@@ -226,7 +237,11 @@ class TestSymSpellPy:
         assert "АБИ" == result[0].term
 
     def test_create_dictionary_invalid_path(self, symspell_default):
-        assert not symspell_default.create_dictionary(INVALID_PATH)
+        with TestCase.assertLogs("symspellpy.symspellpy.logger", level="ERROR") as cm:
+            assert not symspell_default.create_dictionary(INVALID_PATH)
+        assert (
+            f"Corpus not found at {Path(INVALID_PATH)}." == cm.records[0].getMessage()
+        )
 
     def test_create_dictionary(self, symspell_default):
         symspell_default.create_dictionary(BIG_MODIFIED_PATH, encoding="utf-8")


### PR DESCRIPTION
- Log error message when corpus/dictionary files is not found in `create_dictionary()`, `load_dictionary()`, and `load_bigram_dictionary()`.

*Note: chose to log error instead of raising exception to match behavior of the original project.*