### PR TITLE
fix pkg_resources deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ editdistpy>=0.1.3
 coverage==6.1.2
 numpy>=1.19.5
 pytest-cov==3.0.0
+importlib-resources>=6.3.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-import pkg_resources
+import importlib_resources
 import pytest
 
 from symspellpy import SymSpell
@@ -13,17 +13,15 @@ FORTESTS_DIR = Path(__file__).resolve().parent / "fortests"
 #######################################################################
 @pytest.fixture
 def bigram_path():
-    return pkg_resources.resource_filename(
-        "symspellpy", "frequency_bigramdictionary_en_243_342.txt"
-    )
-
+    ref = importlib_resources.files("symspellpy") / "frequency_bigramdictionary_en_243_342.txt"
+    with importlib_resources.as_file(ref) as path:
+        yield path
 
 @pytest.fixture
 def dictionary_path():
-    return pkg_resources.resource_filename(
-        "symspellpy", "frequency_dictionary_en_82_765.txt"
-    )
-
+    ref = importlib_resources.files("symspellpy") / "frequency_dictionary_en_82_765.txt"
+    with importlib_resources.as_file(ref) as path:
+        yield path
 
 @pytest.fixture
 def pickle_path():
@@ -90,3 +88,4 @@ def symspell_short(request):
     if request.param is None:
         return SymSpell(1, 3)
     return SymSpell(1, 3, count_threshold=request.param)
+


### PR DESCRIPTION
Fix `DeprecationWarning: pkg_resources` on python 3.11
According to https://importlib-resources.readthedocs.io/en/latest/migration.html

Replace pkg_resources with importlib_resources

I test on Python 3.9.18 and Python 3.11.8, and work fine, need help testing on the versions below