### PR TITLE
Feature: distance comparer interface

### DIFF
--- a/docs/api/abstract_distance_comparer.rst
+++ b/docs/api/abstract_distance_comparer.rst
@@ -1,0 +1,9 @@
+**************************
+abstract_distance_comparer
+**************************
+
+Distance comparer interface
+===========================
+
+.. autoclass:: symspellpy.abstract_distance_comparer.AbstractDistanceComparer
+   :members:

--- a/docs/api/editdistance.rst
+++ b/docs/api/editdistance.rst
@@ -17,9 +17,6 @@ EditDistance class
 Distance comparer classes
 =========================
 
-.. autoclass:: symspellpy.editdistance.AbstractDistanceComparer
-   :members:
-
 .. autoclass:: symspellpy.editdistance.DamerauOsa
    :members:
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,5 +11,6 @@ Modules
    :maxdepth: 2
 
    helpers.rst
+   abstract_distance_comparer.rst
    editdistance.rst
    symspellpy.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -94,7 +94,8 @@ html_theme = "sphinxdoc"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+#  html_static_path = ["_static"]
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/examples/custom_distance_comparer.rst
+++ b/docs/examples/custom_distance_comparer.rst
@@ -1,0 +1,30 @@
+************************
+Custom distance comparer
+************************
+
+Basic usage
+===========
+
+Create a comparer class which satisfies the interface specified by 
+:class:`~symspellpy.abstract_distance_comparer.AbstractDistanceComparer`:
+
+.. code-block:: python
+
+   from symspellpy.abstract_distance_comparer import AbstractDistanceComparer
+   from symspellpy.editdistance import DistanceAlgorithm, EditDistance
+
+   class CustomComparer(AbstractDistanceComparer):
+       def distance(self, string1, string_2, max_distance):
+           # Compare distance between string_1 and string_2
+           return -1 if distance > max_distance else distance
+
+   custom_comparer = Editdistance(DistanceAlgorithm.USER_PROVIDED, CustomComparer())
+   sym_spell = SymSpell(distance_comparer=custom_comparer)
+   dictionary_path = pkg_resources.resource_filename(
+      "symspellpy", "frequency_bigramdictionary_en_243_342.txt"
+   )
+   sym_spell.load_bigram_dictionary(dictionary_path, 0, 2)
+   
+   # Print out first 5 elements to demonstrate that dictionary is
+   # successfully loaded
+   print(list(islice(sym_spell.bigrams.items(), 5)))

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -8,6 +8,7 @@ Examples
     :maxdepth: 2
 
     dictionary.rst
+    custom_distance_comparer.rst
     lookup.rst
     lookup_compound.rst
     word_segmentation.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@
 symspellpy
 **********
 
-symspellpy is a Python port of SymSpell_ v6.7, a Symmetric Delete
+symspellpy is a Python port of SymSpell_ v6.7.2, a Symmetric Delete
 spelling correction algorithm which provides much higher speed and lower
 memory consumption.
 

--- a/symspellpy/abstract_distance_comparer.py
+++ b/symspellpy/abstract_distance_comparer.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractDistanceComparer(ABC):
+    """An interface to compute relative distance between two strings."""
+
+    @abstractmethod
+    def distance(self, string_1: str, string_2: str, max_distance: int) -> int:
+        """Returns a measure of the distance between two strings.
+
+        Args:
+            string_1: One of the strings to compare.
+            string_2: The other string to compare.
+            max_distance: The maximum distance that is of interest.
+
+        Returns:
+            -1 if the distance is greater than the max_distance, 0 if the strings
+                are equivalent, otherwise a positive number whose magnitude
+                increases as difference between the strings increases.
+        """

--- a/symspellpy/editdistance.py
+++ b/symspellpy/editdistance.py
@@ -18,13 +18,14 @@
    :synopsis: Module for edit distance algorithms.
 """
 
-from abc import ABC, abstractmethod
+import warnings
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 from editdistpy import damerau_osa, levenshtein
 
 from symspellpy import helpers
+from symspellpy.abstract_distance_comparer import AbstractDistanceComparer
 
 
 class DistanceAlgorithm(Enum):
@@ -34,6 +35,7 @@ class DistanceAlgorithm(Enum):
     DAMERAU_OSA = 1  #: Damerau optimal string alignment algorithm
     LEVENSHTEIN_FAST = 2  #: Fast Levenshtein algorithm.
     DAMERAU_OSA_FAST = 3  #: Fast Damerau optimal string alignment algorithm
+    USER_PROVIDED = 4  #: User provided custom edit distance algorithm
 
 
 class EditDistance:
@@ -53,7 +55,16 @@ class EditDistance:
         ValueError: If `algorithm` specifies an invalid distance algorithm.
     """
 
-    def __init__(self, algorithm: DistanceAlgorithm) -> None:
+    def __init__(
+        self,
+        algorithm: DistanceAlgorithm,
+        comparer: Optional[AbstractDistanceComparer] = None,
+    ) -> None:
+        if algorithm != DistanceAlgorithm.USER_PROVIDED and comparer is not None:
+            warnings.warn(
+                f"A comparer is passed in but algorithm is not {DistanceAlgorithm.USER_PROVIDED.value}. A built-in comparer will be used."
+            )
+
         self._distance_comparer: AbstractDistanceComparer
         self._algorithm = algorithm
         if algorithm == DistanceAlgorithm.LEVENSHTEIN:
@@ -64,6 +75,12 @@ class EditDistance:
             self._distance_comparer = LevenshteinFast()
         elif algorithm == DistanceAlgorithm.DAMERAU_OSA_FAST:
             self._distance_comparer = DamerauOsaFast()
+        elif algorithm == DistanceAlgorithm.USER_PROVIDED:
+            if not isinstance(comparer, AbstractDistanceComparer):
+                raise ValueError(
+                    f"{algorithm.value} selected but no comparer passed in."
+                )
+            self._distance_comparer = comparer
         else:
             raise ValueError("unknown distance algorithm")
 
@@ -80,25 +97,6 @@ class EditDistance:
             The edit distance (or -1 if `max_distance` exceeded).
         """
         return self._distance_comparer.distance(string_1, string_2, max_distance)
-
-
-class AbstractDistanceComparer(ABC):
-    """An interface to compute relative distance between two strings."""
-
-    @abstractmethod
-    def distance(self, string_1: str, string_2: str, max_distance: int) -> int:
-        """Returns a measure of the distance between two strings.
-
-        Args:
-            string_1: One of the strings to compare.
-            string_2: The other string to compare.
-            max_distance: The maximum distance that is of interest.
-
-        Returns:
-            -1 if the distance is greater than the max_distance, 0 if the strings
-                are equivalent, otherwise a positive number whose magnitude
-                increases as difference between the strings increases.
-        """
 
 
 class Levenshtein(AbstractDistanceComparer):

--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -84,6 +84,7 @@ class SymSpell(PickleMixin):
         max_dictionary_edit_distance: int = 2,
         prefix_length: int = 7,
         count_threshold: int = 1,
+        distance_comparer: Optional[EditDistance] = None,
     ) -> None:
         if max_dictionary_edit_distance < 0:
             raise ValueError("max_dictionary_edit_distance cannot be negative")
@@ -95,6 +96,10 @@ class SymSpell(PickleMixin):
             )
         if count_threshold < 0:
             raise ValueError("count_threshold cannot be negative")
+        if distance_comparer is None:
+            self.distance_comparer = EditDistance(DistanceAlgorithm.DAMERAU_OSA_FAST)
+        else:
+            self.distance_comparer = distance_comparer
         self._words: Dict[str, int] = {}
         self._below_threshold_words: Dict[str, int] = {}
         self._bigrams: Dict[str, int] = {}
@@ -104,7 +109,7 @@ class SymSpell(PickleMixin):
         self._max_dictionary_edit_distance = max_dictionary_edit_distance
         self._prefix_length = prefix_length
         self._count_threshold = count_threshold
-        self._distance_algorithm = DistanceAlgorithm.DAMERAU_OSA_FAST
+        #  self._distance_algorithm = DistanceAlgorithm.DAMERAU_OSA_FAST
         self._max_length = 0
 
     @property
@@ -128,19 +133,6 @@ class SymSpell(PickleMixin):
         suggestions might have a single suggestion, or multiple suggestions.
         """
         return self._deletes
-
-    @property
-    def distance_algorithm(self) -> DistanceAlgorithm:
-        """The current distance algorithm."""
-        return self._distance_algorithm
-
-    @distance_algorithm.setter
-    def distance_algorithm(self, value: DistanceAlgorithm) -> None:
-        if not isinstance(value, DistanceAlgorithm):
-            raise TypeError(
-                "can only assign DistanceAlgorithm type values to distance_algorithm"
-            )
-        self._distance_algorithm = value
 
     @property
     def entry_count(self) -> int:
@@ -445,7 +437,6 @@ class SymSpell(PickleMixin):
             candidates.append(phrase[:phrase_prefix_len])
         else:
             candidates.append(phrase)
-        distance_comparer = EditDistance(self._distance_algorithm)
         while candidate_pointer < len(candidates):
             candidate = candidates[candidate_pointer]
             candidate_pointer += 1
@@ -577,7 +568,7 @@ class SymSpell(PickleMixin):
                         if suggestion in considered_suggestions:
                             continue
                         considered_suggestions.add(suggestion)
-                        distance = distance_comparer.compare(
+                        distance = self.distance_comparer.compare(
                             phrase, suggestion, max_edit_distance_2
                         )
                         if distance < 0:
@@ -683,7 +674,6 @@ class SymSpell(PickleMixin):
             )
         suggestions = []
         suggestion_parts: List[SuggestItem] = []
-        distance_comparer = EditDistance(self._distance_algorithm)
 
         # translate every item to its best suggestion, otherwise it remains
         # unchanged
@@ -761,7 +751,7 @@ class SymSpell(PickleMixin):
                             continue
                         # select best suggestion for split pair
                         tmp_term = f"{suggestions_1[0].term} {suggestions_2[0].term}"
-                        tmp_distance = distance_comparer.compare(
+                        tmp_distance = self.distance_comparer.compare(
                             terms_1[i], tmp_term, max_edit_distance
                         )
                         if tmp_distance < 0:
@@ -858,7 +848,7 @@ class SymSpell(PickleMixin):
             joined_term = helpers.case_transfer_similar(phrase, joined_term)
         suggestion = SuggestItem(
             joined_term,
-            distance_comparer.compare(phrase, joined_term, 2**31 - 1),
+            self.distance_comparer.compare(phrase, joined_term, 2**31 - 1),
             int(joined_count),
         )
         return [suggestion]


### PR DESCRIPTION
- Make `EditDistance` take in a custom distance comparison algorithm with `DistanceAlgorithm.USER_PROVIDED`
- Make `SymSpell` accept a `EditDistance` object as an argument in the constructor
- Add examples to docs