### PR TITLE
feat: allow file objects as the corpus of `load_dictionary`

### DIFF
--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -314,7 +314,7 @@ class SymSpell(PickleMixin):
 
     def load_dictionary(
         self,
-        corpus: Union[Path, str],
+        corpus: Union[Path, str, IO[str]],
         term_index: int,
         count_index: int,
         separator: str = " ",
@@ -326,7 +326,8 @@ class SymSpell(PickleMixin):
         **NOTE**: Merges with any dictionary data already loaded.
 
         Args:
-            corpus: The path+filename of the file.
+            corpus: The path+filename of the file or a file object of the
+                dictionary.
             term_index: The column position of the word.
             count_index: The column position of the frequency count.
             separator: Separator characters between term(s) and count.
@@ -335,13 +336,18 @@ class SymSpell(PickleMixin):
         Returns:
             ``True`` if file loaded, or ``False`` if file not found.
         """
-        corpus = Path(corpus)
-        if not corpus.exists():
-            logger.error(f"Dictionary file not found at {corpus}.")
-            return False
-        with open(corpus, "r", encoding=encoding) as infile:
+        if isinstance(corpus, (Path, str)):
+            corpus = Path(corpus)
+            if not corpus.exists():
+                logger.error(f"Dictionary file not found at {corpus}.")
+                return False
+            with open(corpus, "r", encoding=encoding) as infile:
+                return self._load_dictionary_stream(
+                    infile, term_index, count_index, separator
+                )
+        else:
             return self._load_dictionary_stream(
-                infile, term_index, count_index, separator
+                corpus, term_index, count_index, separator
             )
 
     def lookup(

--- a/tests/test_symspellpy.py
+++ b/tests/test_symspellpy.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from pathlib import Path
 from unittest import TestCase
 
@@ -238,6 +239,18 @@ class TestSymSpellPy:
         result = symspell_default.lookup("АБ", Verbosity.TOP, 2)
         assert 1 == len(result)
         assert "АБИ" == result[0].term
+
+    def test_load_dictionary_from_string_io(self, symspell_default, dictionary_path):
+        with open(dictionary_path, "r") as f:
+            symspell_default.load_dictionary(StringIO(f.read()), 0, 1)
+            assert 82834 == symspell_default.word_count
+            assert 676094 == symspell_default.entry_count
+
+    def test_load_dictionary_from_text_io_wrapper(self, symspell_default, dictionary_path):
+        with open(dictionary_path, "r") as f:
+            symspell_default.load_dictionary(f, 0, 1)
+            assert 82834 == symspell_default.word_count
+            assert 676094 == symspell_default.entry_count
 
     def test_create_dictionary_invalid_path(self, symspell_default):
         with TestCase.assertLogs("symspellpy.symspellpy.logger", level="ERROR") as cm:


### PR DESCRIPTION
## Overview

* Support file objects to load a dictionary
  * Currently, we need to create a file to load a dictionary even if we have data in memory. This change allows us to use the data in memory when loading a dictionary

## Testing

* I've added unit tests to verify the changes
