### PR TITLE
refactor: make editdistpy optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "symspellpy"
 version = "6.9.0"
-dependencies = [
-    "editdistpy>=0.1.3",
-]
+dependencies = []
 requires-python = ">=3.10"
 authors = [
     {name = "mmb L"},
@@ -36,8 +34,14 @@ Repository = "https://github.com/mammothb/symspellpy"
 Documentation = "https://symspellpy.readthedocs.io/en/latest"
 Changelog = "https://github.com/mammothb/symspellpy/blob/master/CHANGELOG.md"
 
+[project.optional-dependencies]
+editdistpy = [
+    "editdistpy>=0.1.3",
+]
+
 [dependency-groups]
 dev = [
+    "editdistpy>=0.1.3",
     "pytest==9.0.3",
     "pytest-cov==6.0.0",
     "pytest-xdist==3.8.0",

--- a/symspellpy/editdistance.py
+++ b/symspellpy/editdistance.py
@@ -20,8 +20,10 @@
 
 import warnings
 from enum import Enum
+from typing import TYPE_CHECKING
 
-from editdistpy import damerau_osa, levenshtein
+if TYPE_CHECKING:
+    from editdistpy import damerau_osa, levenshtein
 
 from symspellpy import helpers
 from symspellpy.abstract_distance_comparer import AbstractDistanceComparer
@@ -447,7 +449,17 @@ class LevenshteinFast(AbstractDistanceComparer):
             -1 if the distance is greater than the max_distance, 0 if the strings
                 are equivalent, otherwise a positive number whose magnitude
                 increases as difference between the strings increases.
+
+        Raises:
+            ImportError: If the optional 'editdistpy' dependency is not installed.
         """
+        try:
+            from editdistpy import levenshtein
+        except ImportError:
+            raise ImportError(
+                "LevenshteinFast requires the 'editdistpy' package. "
+                "Install with: pip install symspellpy[editdistpy]"
+            ) from None
         return levenshtein.distance(string_1, string_2, max_distance)
 
 
@@ -472,5 +484,15 @@ class DamerauOsaFast(AbstractDistanceComparer):
             -1 if the distance is greater than the max_distance, 0 if the strings
                 are equivalent, otherwise a positive number whose magnitude
                 increases as difference between the strings increases.
+
+        Raises:
+            ImportError: If the optional 'editdistpy' dependency is not installed.
         """
+        try:
+            from editdistpy import damerau_osa
+        except ImportError:
+            raise ImportError(
+                "DamerauOsaFast requires the 'editdistpy' package. "
+                "Install with: pip install symspellpy[editdistpy]"
+            ) from None
         return damerau_osa.distance(string_1, string_2, max_distance)

--- a/symspellpy/symspellpy.py
+++ b/symspellpy/symspellpy.py
@@ -99,7 +99,7 @@ class SymSpell(PickleMixin):
         if count_threshold < 0:
             raise ValueError("count_threshold cannot be negative")
         if distance_comparer is None:
-            self.distance_comparer = EditDistance(DistanceAlgorithm.DAMERAU_OSA_FAST)
+            self.distance_comparer = EditDistance(DistanceAlgorithm.DAMERAU_OSA)
         else:
             self.distance_comparer = distance_comparer
         self._words: dict[str, int] = {}

--- a/tests/test_editdistance.py
+++ b/tests/test_editdistance.py
@@ -1,7 +1,6 @@
 import sys
 from collections.abc import Callable, Generator
 from itertools import combinations, permutations
-from typing import TypedDict
 
 import pytest
 
@@ -14,6 +13,13 @@ from symspellpy.editdistance import (
     Levenshtein,
     LevenshteinFast,
 )
+
+try:
+    import editdistpy
+
+    EDITDISTPY_AVAILABLE = True
+except ImportError:
+    EDITDISTPY_AVAILABLE = False
 
 SHORT_STRING = "string"
 LONG_STRING = "long_string"
@@ -71,68 +77,57 @@ class CustomDistanceComparer(AbstractDistanceComparer):
         return -2
 
 
-class _ComparerEntry(TypedDict):
-    actual: AbstractDistanceComparer
-    expected: Callable[[str, str, int], int]
+_COMPARER_PARAMS = ["damerau_osa", "levenshtein"]
+if EDITDISTPY_AVAILABLE:
+    _COMPARER_PARAMS += ["damerau_osa_fast", "levenshtein_fast"]
 
 
-@pytest.fixture(
-    params=["damerau_osa", "levenshtein", "damerau_osa_fast", "levenshtein_fast"]
-)
+def _get_comparer_entry(
+    name: str,
+) -> tuple[AbstractDistanceComparer, Callable[[str, str, int], int]]:
+    """Build a comparer and its reference function, by name."""
+    match name:
+        case "damerau_osa":
+            return DamerauOsa(), expected_damerau_osa
+        case "levenshtein":
+            return Levenshtein(), expected_levenshtein
+        case "damerau_osa_fast":
+            return DamerauOsaFast(), expected_damerau_osa
+        case "levenshtein_fast":
+            return LevenshteinFast(), expected_levenshtein
+        case _:
+            raise ValueError(f"Unknown comparer: {name}")
+
+
+@pytest.fixture(params=_COMPARER_PARAMS)
 def get_comparer(
     request: pytest.FixtureRequest,
 ) -> Generator[tuple[AbstractDistanceComparer, Callable[[str, str, int], int]]]:
-    comparer_dict: dict[str, _ComparerEntry] = {
-        "damerau_osa": {"actual": DamerauOsa(), "expected": expected_damerau_osa},
-        "levenshtein": {"actual": Levenshtein(), "expected": expected_levenshtein},
-        "damerau_osa_fast": {
-            "actual": DamerauOsaFast(),
-            "expected": expected_damerau_osa,
-        },
-        "levenshtein_fast": {
-            "actual": LevenshteinFast(),
-            "expected": expected_levenshtein,
-        },
-    }
-    yield (
-        comparer_dict[request.param]["actual"],
-        comparer_dict[request.param]["expected"],
-    )
+    yield _get_comparer_entry(request.param)
 
 
-class _EditDistanceEntry(TypedDict):
-    actual: EditDistance
-    expected: type[AbstractDistanceComparer]
+def _get_edit_distance_entry(
+    name: str,
+) -> tuple[EditDistance, type[AbstractDistanceComparer]]:
+    """Build an EditDistance wrapper and its expected comparer type, by name."""
+    match name:
+        case "damerau_osa":
+            return EditDistance(DistanceAlgorithm.DAMERAU_OSA), DamerauOsa
+        case "levenshtein":
+            return EditDistance(DistanceAlgorithm.LEVENSHTEIN), Levenshtein
+        case "damerau_osa_fast":
+            return EditDistance(DistanceAlgorithm.DAMERAU_OSA_FAST), DamerauOsaFast
+        case "levenshtein_fast":
+            return EditDistance(DistanceAlgorithm.LEVENSHTEIN_FAST), LevenshteinFast
+        case _:
+            raise ValueError(f"Unknown edit distance entry: {name}")
 
 
-@pytest.fixture(
-    params=["damerau_osa", "levenshtein", "damerau_osa_fast", "levenshtein_fast"]
-)
+@pytest.fixture(params=_COMPARER_PARAMS)
 def get_edit_distance(
     request: pytest.FixtureRequest,
 ) -> Generator[tuple[EditDistance, type[AbstractDistanceComparer]]]:
-    comparer_dict: dict[str, _EditDistanceEntry] = {
-        "damerau_osa": {
-            "actual": EditDistance(DistanceAlgorithm.DAMERAU_OSA),
-            "expected": DamerauOsa,
-        },
-        "levenshtein": {
-            "actual": EditDistance(DistanceAlgorithm.LEVENSHTEIN),
-            "expected": Levenshtein,
-        },
-        "damerau_osa_fast": {
-            "actual": EditDistance(DistanceAlgorithm.DAMERAU_OSA_FAST),
-            "expected": DamerauOsaFast,
-        },
-        "levenshtein_fast": {
-            "actual": EditDistance(DistanceAlgorithm.LEVENSHTEIN_FAST),
-            "expected": LevenshteinFast,
-        },
-    }
-    yield (
-        comparer_dict[request.param]["actual"],
-        comparer_dict[request.param]["expected"],
-    )
+    yield _get_edit_distance_entry(request.param)
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -195,8 +195,17 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pytest"
-version = "8.3.4"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -204,11 +213,12 @@ dependencies = [
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919, upload-time = "2024-12-01T12:54:25.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083, upload-time = "2024-12-01T12:54:19.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -241,23 +251,28 @@ wheels = [
 name = "symspellpy"
 version = "6.9.0"
 source = { editable = "." }
-dependencies = [
+
+[package.optional-dependencies]
+editdistpy = [
     { name = "editdistpy" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "editdistpy" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "editdistpy", specifier = ">=0.1.3" }]
+requires-dist = [{ name = "editdistpy", marker = "extra == 'editdistpy'", specifier = ">=0.1.3" }]
+provides-extras = ["editdistpy"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = "==8.3.4" },
+    { name = "editdistpy", specifier = ">=0.1.3" },
+    { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-cov", specifier = "==6.0.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
 ]


### PR DESCRIPTION
closes #153 

Makes editdistpy optional so symspellpy still can be used on platforms where editdistpy is not supported